### PR TITLE
Made the table rebuildable on demand if data changes

### DIFF
--- a/js/Default.js
+++ b/js/Default.js
@@ -50,7 +50,8 @@ kawasu.orders.init = function () {
         styleDefn,
         "myMicroTable",
         "Order: ",
-        kawasu.microtable.config.STACK);
+        //kawasu.microtable.config.STACK);
+        kawasu.microtable.config.VERTICAL);
 
     if (fc.utils.isValidVar(myMicroTable)) {
         divContainer.appendChild(myMicroTable);
@@ -69,7 +70,8 @@ kawasu.orders.init = function () {
     //$("#divContainer").remove(myMicroTable); // Drop tables from DOM
     //$("#divContainer").append(myMicroTableRebuilt);
 
-    divContainer.removeChild(myMicroTable);
+    //divContainer.removeChild(myMicroTable);
+    while (divContainer.lastChild) { divContainer.removeChild(divContainer.lastChild); }
     divContainer.appendChild(myMicroTableRebuilt);
 
     // END TEST:


### PR DESCRIPTION
CHANGED: Harness DEFAULT.JS to drop existing tables and attach new ones
CHANGED: build() function now returns a NodeList instead of an array
CHANGED: Internal references to array changed to NodeList compliant equivalents
CHANGED: rebuild() fn to ensure new header is created before tables rebuild
CHANGED: Controls now find raw tables by relative path using name
