### PR TITLE
Implemented expandable rows in Vertical mode, with Single/Multi sub-mode

### DIFF
--- a/Default.aspx
+++ b/Default.aspx
@@ -25,6 +25,9 @@
         <br />
         <input type="button" id="btnSelectAll" value="Select All" />
         <input type="button" id="btnDeselectAll" value="Deselect All" />
+        <input type="button" id="btnToggleExpandable" value="Toggle Expandable" />
+        <input type="button" id="btnToggleMultiSingleExp" value="Toggle Multi-Single Exp" />
+
         
         <br />
         <br />

--- a/js/Default.js
+++ b/js/Default.js
@@ -179,6 +179,12 @@ kawasu.orders.hookupHandlers = function () {
 
     var btnDeselectAll = document.getElementById("btnDeselectAll");
     fc.utils.addEvent(btnDeselectAll, "click", kawasu.orders.btnDeselectAll_onClick);
+
+    var btnToggleExpandable = document.getElementById("btnToggleExpandable");
+    fc.utils.addEvent(btnToggleExpandable, "click", kawasu.orders.btnToggleExpandable_onClick);
+
+    var btnToggleMultiSingleExp = document.getElementById("btnToggleMultiSingleExp");
+    fc.utils.addEvent(btnToggleMultiSingleExp, "click", kawasu.orders.btnToggleMultiSingleExp_onClick);
 }
 
 kawasu.orders.btnDeleteItem_onClick = function () {
@@ -231,6 +237,32 @@ kawasu.orders.btnDeselectAll_onClick = function () {
     console.log(prefix + "Entering");
 
     kawasu.microtable.setSelectAll("myMicroTable", false);
+
+    console.log(prefix + "Exiting");
+}
+
+kawasu.orders.btnToggleExpandable_onClick = function () {
+    var prefix = "kawasu.orders.btnToggleExpandable_onClick() - ";
+    console.log(prefix + "Entering");
+
+    kawasu.microtable.expandable("myMicroTable") ?
+        kawasu.microtable.expandable("myMicroTable", false) :
+        kawasu.microtable.expandable("myMicroTable", true);
+
+    kawasu.microtable.refreshView("myMicroTable");
+
+    console.log(prefix + "Exiting");
+}
+
+kawasu.orders.btnToggleMultiSingleExp_onClick = function () {
+    var prefix = "kawasu.orders.btnToggleMultiSingleExp_onClick() - ";
+    console.log(prefix + "Entering");
+
+    kawasu.microtable.multiExpand("myMicroTable") ?
+        kawasu.microtable.multiExpand("myMicroTable", false) :
+        kawasu.microtable.multiExpand("myMicroTable", true);
+
+    kawasu.microtable.refreshView("myMicroTable");
 
     console.log(prefix + "Exiting");
 }

--- a/js/MicroTable.js
+++ b/js/MicroTable.js
@@ -40,43 +40,44 @@ kawasu.microtable.config.sEmptyStringHtml = "&nbsp;";
 // ENTRY POINT
 //
 
-kawasu.microtable.build = function (arrData, styleDefn, sTableID, sItemName, nRowsMinimum, bMultiSelect, nViewState) {
+kawasu.microtable.build = function (arrData, styleDefn, sTableId, sItemName, nRowsMinimum, bMultiSelect, nViewState) {
     var prefix = "kawasu.microtable.build() - ";
     console.log(prefix + "Entering");
 
     // Cache the styleDefn for use later.  All data pertaining to this table
     // will then be stored in this area.
-    kawasu.microtable[sTableID] = new Object();
-    kawasu.microtable[sTableID]["arrData"] = arrData;
-    kawasu.microtable[sTableID]["styleDefn"] = styleDefn;
-    kawasu.microtable[sTableID]["nViewState"] = nViewState;
-    kawasu.microtable[sTableID]["sItemName"] = sItemName;
-    kawasu.microtable[sTableID]["nRowsMinimum"] = nRowsMinimum;
-    kawasu.microtable[sTableID]["bMultiSelect"] = bMultiSelect;
-
+    kawasu.microtable[sTableId] = new Object();
+    kawasu.microtable[sTableId]["arrData"] = arrData;
+    kawasu.microtable[sTableId]["styleDefn"] = styleDefn;
+    kawasu.microtable[sTableId]["nViewState"] = nViewState;
+    kawasu.microtable[sTableId]["sItemName"] = sItemName;
+    kawasu.microtable[sTableId]["nRowsMinimum"] = nRowsMinimum;
+    kawasu.microtable[sTableId]["bMultiSelect"] = bMultiSelect;
+    kawasu.microtable[sTableId]["bExpandable"] = false;
+    kawasu.microtable[sTableId]["bMultiExpand"] = false;
 
 
     // Header object is created by walking the inbound data and 
     // creating a property on a new object for every unique 
     // property on the objects in the arrData array.
-    kawasu.microtable[sTableID]["header"] = kawasu.microtable.buildHeaderData(arrData);
+    kawasu.microtable[sTableId]["header"] = kawasu.microtable.buildHeaderData(arrData);
 
-    var rawTables = kawasu.microtable.buildRawTables(sTableID); // returns nodelist of tables
+    var rawTables = kawasu.microtable.buildRawTables(sTableId); // returns nodelist of tables
 
     if (fc.utils.isInvalidVar(rawTables)) {
         console.log(prefix + "ERROR: Failed to create raw tables.");
         return;
     }
     else {
-        kawasu.microtable.applyViewState(sTableID, rawTables);
+        kawasu.microtable.applyViewState(sTableId, rawTables);
         console.log(prefix + "Exiting");
         return rawTables;
     }
 
     // DIAGNOSTICS
     // Iterate returned array and display tables
-    //for (var i = 0; i < kawasu.microtable[sTableID]["rawTables"].length; ++i) {
-    //    (document.getElementById("divContainer")).appendChild(kawasu.microtable[sTableID]["rawTables"][i]);
+    //for (var i = 0; i < kawasu.microtable[sTableId]["rawTables"].length; ++i) {
+    //    (document.getElementById("divContainer")).appendChild(kawasu.microtable[sTableId]["rawTables"][i]);
     //}
     // END DIAGNOSTICS
 
@@ -119,7 +120,7 @@ kawasu.microtable.buildHeaderData = function (arrayJsonObjects) {
     console.log(prefix + "Exiting");
 }
 
-kawasu.microtable.buildRawTables = function (sTableID) {
+kawasu.microtable.buildRawTables = function (sTableId) {
     var prefix = "kawasu.microtable.buildRawTables() - ";
     console.log(prefix + "Entering");
 
@@ -127,15 +128,15 @@ kawasu.microtable.buildRawTables = function (sTableID) {
     // This fn takes an array of JSON objects and creates a set of HTML table from them, 
     // one table per object, applying the styles listed in the styleDefn object.
 
-    var arrData = kawasu.microtable[sTableID]["arrData"];
-    var header = kawasu.microtable[sTableID]["header"];
-    var sItemName = kawasu.microtable[sTableID]["sItemName"];
-    var styleDefn = kawasu.microtable[sTableID]["styleDefn"];
-    var nRowsMinimum = kawasu.microtable[sTableID]["nRowsMinimum"];             // Pad to this number of rows
+    var arrData = kawasu.microtable[sTableId]["arrData"];
+    var header = kawasu.microtable[sTableId]["header"];
+    var sItemName = kawasu.microtable[sTableId]["sItemName"];
+    var styleDefn = kawasu.microtable[sTableId]["styleDefn"];
+    var nRowsMinimum = kawasu.microtable[sTableId]["nRowsMinimum"];             // Pad to this number of rows
 
     var nRowsRequired = nRowsMinimum - kawasu.microtable.countHeaders(header);
 
-    kawasu.microtable[sTableID]["indexCurrentRow"] = 1;
+    kawasu.microtable[sTableId]["indexCurrentRow"] = 1;
 
     var rawTables = document.createDocumentFragment();
 
@@ -157,8 +158,8 @@ kawasu.microtable.buildRawTables = function (sTableID) {
     var tableControl = document.createElement("table");
     var classTable = styleDefn["tableClass"] || "";
     tableControl.className = classTable;
-    //tableControl.id = sTableID + "_Control";
-    tableControl.id = kawasu.microtable.getTableId(sTableID, 0);
+    //tableControl.id = sTableId + "_Control";
+    tableControl.id = kawasu.microtable.getTableId(sTableId, 0);
 
     var trHeaderControl = document.createElement("tr");
     trHeaderControl.className = classRowHeader;
@@ -173,8 +174,8 @@ kawasu.microtable.buildRawTables = function (sTableID) {
     th1Control.appendChild(labelRowNavigate);
     var textboxRowNavigate = document.createElement("input");
     textboxRowNavigate.type = "textbox";
-    textboxRowNavigate.id = sTableID + "_" + "textboxRowNavigate";
-    textboxRowNavigate.value = (kawasu.microtable[sTableID]["indexCurrentRow"]);
+    textboxRowNavigate.id = sTableId + "_" + "textboxRowNavigate";
+    textboxRowNavigate.value = (kawasu.microtable[sTableId]["indexCurrentRow"]);
     textboxRowNavigate.className = classTextboxRowNavigate;
 
     fc.utils.addEvent(textboxRowNavigate, "change", kawasu.microtable.textboxRowNavigate_onChange);
@@ -193,7 +194,7 @@ kawasu.microtable.buildRawTables = function (sTableID) {
     // First Row Button
     var btnRowFirst = document.createElement("input");
     btnRowFirst.type = "button";
-    btnRowFirst.id = sTableID + "_" + "btnRowFirst";
+    btnRowFirst.id = sTableId + "_" + "btnRowFirst";
     btnRowFirst.value = "<<";
     btnRowFirst.title = "First";
     btnRowFirst.className = classBtnRowNavigate;
@@ -203,7 +204,7 @@ kawasu.microtable.buildRawTables = function (sTableID) {
     // Previous Row Button
     var btnRowPrev = document.createElement("input");
     btnRowPrev.type = "button";
-    btnRowPrev.id = sTableID + "_" + "btnRowPrev";
+    btnRowPrev.id = sTableId + "_" + "btnRowPrev";
     btnRowPrev.value = "<";
     btnRowPrev.title = "Previous";
     btnRowPrev.className = classBtnRowNavigate;
@@ -213,7 +214,7 @@ kawasu.microtable.buildRawTables = function (sTableID) {
     // Next Row Button
     var btnRowNext = document.createElement("input");
     btnRowNext.type = "button";
-    btnRowNext.id = sTableID + "_" + "btnRowNext";
+    btnRowNext.id = sTableId + "_" + "btnRowNext";
     btnRowNext.value = ">";
     btnRowNext.title = "Next";
     btnRowNext.className = classBtnRowNavigate;
@@ -223,7 +224,7 @@ kawasu.microtable.buildRawTables = function (sTableID) {
     // Last Row Button
     var btnRowLast = document.createElement("input");
     btnRowLast.type = "button";
-    btnRowLast.id = sTableID + "_" + "btnRowLast";
+    btnRowLast.id = sTableId + "_" + "btnRowLast";
     btnRowLast.value = ">>";
     btnRowLast.title = "Last";
     btnRowLast.className = classBtnRowNavigate;
@@ -233,7 +234,7 @@ kawasu.microtable.buildRawTables = function (sTableID) {
     // Select Checkbox
     var checkboxControlSelect = document.createElement("input");
     checkboxControlSelect.type = "checkbox";
-    checkboxControlSelect.id = sTableID + "_" + "checkboxSelect";
+    checkboxControlSelect.id = sTableId + "_" + "checkboxSelect";
     checkboxControlSelect.title = "Select";
     checkboxControlSelect.className = classCheckboxSelect;
     fc.utils.addEvent(checkboxControlSelect, "click", kawasu.microtable.checkboxSelect_onClick);
@@ -249,11 +250,14 @@ kawasu.microtable.buildRawTables = function (sTableID) {
     // Add dummy rows in case we have to show a blank table
     //
 
-    kawasu.microtable.addRow(sTableID, tableControl, true, kawasu.microtable.getItemText(sItemName, 0)); // Native header row "Row:0"
+    var tableControlNativeHeader = kawasu.microtable.addRow(sTableId, tableControl, true, kawasu.microtable.getItemText(sItemName, 0)); // Native header row "Row:0"
+    var tableControlNativeHeaderCellCol1 = tableControlNativeHeader.cells[0];
+    fc.utils.addEvent(tableControlNativeHeaderCellCol1, "click", kawasu.microtable.thNativeHeader_onClick);
+
 
     // Add the minimum number of blank rows
     for (var j = 0; j < nRowsMinimum; ++j) {
-        kawasu.microtable.addRow(sTableID, tableControl, false); // bHeader=false ie "td", not "th"
+        kawasu.microtable.addRow(sTableId, tableControl, false); // bHeader=false ie "td", not "th"
     }
 
     rawTables.appendChild(tableControl);
@@ -270,10 +274,12 @@ kawasu.microtable.buildRawTables = function (sTableID) {
         // Make table
         var table = document.createElement("table");
         table.className = classTable;
-        table.id = kawasu.microtable.getTableId(sTableID, i + 1);
+        table.id = kawasu.microtable.getTableId(sTableId, i + 1);
 
         // Add native header
-        var trHeader = kawasu.microtable.addRow(sTableID, table, true, kawasu.microtable.getItemText(sItemName, i + 1));
+        var trNativeHeader = kawasu.microtable.addRow(sTableId, table, true, kawasu.microtable.getItemText(sItemName, i + 1));
+        var trNativeHeaderCellCol1 = trNativeHeader.cells[0];
+        fc.utils.addEvent(trNativeHeaderCellCol1, "click", kawasu.microtable.thNativeHeader_onClick);
 
         // Add a checkbox to the native header 2nd cell
         var checkboxSelect = document.createElement("input");
@@ -281,21 +287,21 @@ kawasu.microtable.buildRawTables = function (sTableID) {
         checkboxSelect.id = table.id + "_" + "checkboxSelect";
         checkboxSelect.className = classCheckboxSelect;
         fc.utils.addEvent(checkboxSelect, "click", kawasu.microtable.checkboxSelect_onClick);
-        trHeader.cells[1].appendChild(checkboxSelect);
+        trNativeHeader.cells[1].appendChild(checkboxSelect);
 
 
         // Iterate the header object, and add one row per header element.
         // Each header element is a key, and there should be a value in the data element.
         for (var prop in header) {
             if (header.hasOwnProperty(prop)) {
-                kawasu.microtable.addRow(sTableID, table, false, prop, obj[prop]);
+                kawasu.microtable.addRow(sTableId, table, false, prop, obj[prop]);
             }
 
         } // end of iteration of data object's properties (rows for each object as a table)
 
         // Pad with blank rows if required
         for (var k = 0; k < nRowsRequired; ++k) {
-            kawasu.microtable.addRow(sTableID, table, false);
+            kawasu.microtable.addRow(sTableId, table, false);
         }
 
         rawTables.appendChild(table);
@@ -307,7 +313,7 @@ kawasu.microtable.buildRawTables = function (sTableID) {
     console.log(prefix + "Exiting");
 }
 
-kawasu.microtable.rebuild = function (sTableID) {
+kawasu.microtable.rebuild = function (sTableId) {
     var prefix = "kawasu.microtable.rebuild() - ";
     console.log(prefix + "Entering");
 
@@ -319,11 +325,11 @@ kawasu.microtable.rebuild = function (sTableID) {
     //          The reference to arrData is still valid.
 
     // Build first, and then swap new built data into place
-    kawasu.microtable[sTableID]["header"] = kawasu.microtable.buildHeaderData(kawasu.microtable[sTableID]["arrData"]);
-    var rawTables_rebuild = kawasu.microtable.buildRawTables(sTableID);
+    kawasu.microtable[sTableId]["header"] = kawasu.microtable.buildHeaderData(kawasu.microtable[sTableId]["arrData"]);
+    var rawTables_rebuild = kawasu.microtable.buildRawTables(sTableId);
 
     // Apply view state
-    kawasu.microtable.applyViewState(sTableID,rawTables_rebuild);
+    kawasu.microtable.applyViewState(sTableId,rawTables_rebuild);
 
     console.log(prefix + "Exiting");
 
@@ -344,7 +350,7 @@ kawasu.microtable.rebuild = function (sTableID) {
 // VIEW STATE
 //
 
-kawasu.microtable.viewState = function (sTableID, nViewState) {
+kawasu.microtable.viewState = function (sTableId, nViewState) {
     var prefix = "kawasu.microtable.viewState() - ";
     console.log(prefix + "Entering");
 
@@ -352,48 +358,45 @@ kawasu.microtable.viewState = function (sTableID, nViewState) {
 
     if (typeof nViewState !== 'undefined') {
         // Setting
-        kawasu.microtable[sTableID]["nViewState"] = nViewState;
-        kawasu.microtable.applyViewState(sTableID);
+        kawasu.microtable[sTableId]["nViewState"] = nViewState;
+        kawasu.microtable.applyViewState(sTableId);
     }
 
     // Either way, return the viewstate...
-    return kawasu.microtable[sTableID]["nViewState"];
+    return kawasu.microtable[sTableId]["nViewState"];
 
     console.log(prefix + "Exiting");
 }
 
-kawasu.microtable.applyViewState = function (sTableID, rawTables) {
+kawasu.microtable.applyViewState = function (sTableId, rawTables) {
     var prefix = "kawasu.microtable.applyViewState() - ";
     console.log(prefix + "Entering");
 
-    if (typeof rawTables === 'undefined') { rawTables = kawasu.microtable.getRawTables(sTableID); }
+    if (typeof rawTables === 'undefined') { rawTables = kawasu.microtable.getRawTables(sTableId); }
 
     if (typeof rawTables === 'undefined') {
-        console.log(prefix + "ERROR:EXITING: Could not locate raw tables from sTableID: >" + sTableID + "<");
+        console.log(prefix + "ERROR:EXITING: Could not locate raw tables from sTableId: >" + sTableId + "<");
         return;
     }
 
-    var nViewState = kawasu.microtable[sTableID]["nViewState"];
-    var indexCurrentRow = kawasu.microtable[sTableID]["indexCurrentRow"];
+    var nViewState = kawasu.microtable[sTableId]["nViewState"];
+    var indexCurrentRow = kawasu.microtable[sTableId]["indexCurrentRow"];
 
     switch (nViewState) {
         case kawasu.microtable.config.VERTICAL:
-            kawasu.microtable.setViewStateVertical(rawTables, indexCurrentRow);
+            kawasu.microtable.setViewStateVertical(sTableId, rawTables, indexCurrentRow);
             break;
         default:
             console.log(prefix + "WARNING: Unknown view state value detected (" + nViewState + "); defaulting to STACK");
         case kawasu.microtable.config.STACK:
-            kawasu.microtable.setViewStateStack(sTableID, rawTables, indexCurrentRow);
+            kawasu.microtable.setViewStateStack(sTableId, rawTables, indexCurrentRow);
             break;
     }
     console.log(prefix + "Exiting");
 }
 
-kawasu.microtable.setElementVis = function (element, bShow) {
-    element.style.display = (bShow) ? "" : "none";
-}
 
-kawasu.microtable.setViewStateStack = function (sTableID, rawTables, indexCurrentRow) {
+kawasu.microtable.setViewStateStack = function (sTableId, rawTables, indexCurrentRow) {
     var prefix = "kawasu.microtable.setViewStateStack() - ";
     console.log(prefix + "Entering");
 
@@ -404,18 +407,18 @@ kawasu.microtable.setViewStateStack = function (sTableID, rawTables, indexCurren
 
     var tableControl = rawTables.children[0];
     var controlCheckbox = kawasu.microtable.getCheckboxFromTable(tableControl);
-    kawasu.microtable.setElementVis(tableControl, true);
+    kawasu.microtable.elementVis(tableControl, true);
 
     var nodeListLength = rawTables.children.length;
 
     // Ensure that the current row is legal and up to date
-    if (kawasu.microtable[sTableID]["indexCurrentRow"] > (nodeListLength - 1)) {
-        kawasu.microtable[sTableID]["indexCurrentRow"] = nodeListLength - 1;
+    if (kawasu.microtable[sTableId]["indexCurrentRow"] > (nodeListLength - 1)) {
+        kawasu.microtable[sTableId]["indexCurrentRow"] = nodeListLength - 1;
     }
 
     // Get a ref to the textbox
     var textbox = kawasu.microtable.getTextboxFromTable(tableControl);
-    textbox.value = kawasu.microtable[sTableID]["indexCurrentRow"];
+    textbox.value = kawasu.microtable[sTableId]["indexCurrentRow"];
 
 
     // Special Case: No data to show
@@ -424,11 +427,11 @@ kawasu.microtable.setViewStateStack = function (sTableID, rawTables, indexCurren
         // If there is only a control table, show the blank padding rows, but don't show
         // the native header row
 
-        kawasu.microtable.setElementVis(tableControl.rows[0], true); // Show the control header
-        kawasu.microtable.setElementVis(tableControl.rows[1], false); // Hide the native header
+        kawasu.microtable.elementVis(tableControl.rows[0], true); // Show the control header
+        kawasu.microtable.elementVis(tableControl.rows[1], false); // Hide the native header
 
         for (var j = 2; j < tableControl.rows.length; ++j) {
-            kawasu.microtable.setElementVis(tableControl.rows[j], true); // Show the padding rows         
+            kawasu.microtable.elementVis(tableControl.rows[j], true); // Show the padding rows         
         }
 
         controlCheckbox.checked = false;
@@ -441,33 +444,36 @@ kawasu.microtable.setViewStateStack = function (sTableID, rawTables, indexCurren
     // Regular Case: Data to display
 
     // Show the control table
-    kawasu.microtable.setElementVis(tableControl.rows[0], true); // Show the control header
-    kawasu.microtable.setElementVis(tableControl.rows[1], false); // Hide the native header
+    kawasu.microtable.elementVis(tableControl.rows[0], true); // Show the control header
+    kawasu.microtable.elementVis(tableControl.rows[1], false); // Hide the native header
 
     for (var j = 2; j < tableControl.rows.length; ++j) {
-        kawasu.microtable.setElementVis(tableControl.rows[j], false); // Hide the padding rows         
+        kawasu.microtable.elementVis(tableControl.rows[j], false); // Hide the padding rows         
     }
 
     // Show the data 
     for (var i = 1; i < nodeListLength; ++i) {
         var table = rawTables.children[i];
         if (i == indexCurrentRow) {
-            kawasu.microtable.setElementVis(table, true); // Show table
-            kawasu.microtable.setElementVis(table.rows[0], false); // Hide native header
+            kawasu.microtable.elementVis(table.rows[0], false); // Hide native header
+            for (var j = 1; j < table.rows.length; ++j) {
+                kawasu.microtable.elementVis(table.rows[j], true); // Show the data rows
+            }
+            kawasu.microtable.elementVis(table, true); // Show table
 
             // Set the control checkbox equal to the current row checkbox
             var checkbox = kawasu.microtable.getCheckboxFromTable(table);
             controlCheckbox.checked = checkbox.checked;
         }
         else {
-            kawasu.microtable.setElementVis(table, false); // Hide table
+            kawasu.microtable.elementVis(table, false); // Hide table
         }
     }
 
     console.log(prefix + "Exiting");
 }
 
-kawasu.microtable.setViewStateVertical = function (rawTables, indexCurrentRow) {
+kawasu.microtable.setViewStateVertical = function (sTableId, rawTables, indexCurrentRow) {
     var prefix = "kawasu.microtable.setViewStateVertical() - ";
     console.log(prefix + "Entering");
 
@@ -475,20 +481,23 @@ kawasu.microtable.setViewStateVertical = function (rawTables, indexCurrentRow) {
     // Show all the row tables sequentially.  
     // Show the row's native header.
 
+    var bExpandable = kawasu.microtable[sTableId]["bExpandable"];
+
     var tableControl = rawTables.children[0];
     var nodeListLength = rawTables.children.length;
+
 
     // Special Case: No data to show
     if (nodeListLength == 1) {
 
-        kawasu.microtable.setElementVis(tableControl.rows[0], false); // Hide the control header
-        kawasu.microtable.setElementVis(tableControl.rows[1], true); // Show the native header
+        kawasu.microtable.elementVis(tableControl.rows[0], false); // Hide the control header
+        kawasu.microtable.elementVis(tableControl.rows[1], true); // Show the native header
 
         for (var j = 2; j < tableControl.rows.length; ++j) {
-            kawasu.microtable.setElementVis(tableControl.rows[j], true); // Show the padding rows         
+            kawasu.microtable.elementVis(tableControl.rows[j], true); // Show the padding rows         
         }
 
-        kawasu.microtable.setElementVis(tableControl, true); // Having set up the elements of the control table, show it
+        kawasu.microtable.elementVis(tableControl, true); // Having set up the elements of the control table, show it
         return;
     }
     // implicit else
@@ -497,14 +506,19 @@ kawasu.microtable.setViewStateVertical = function (rawTables, indexCurrentRow) {
     // Regular Case: Data to show...
 
     // Hide the control table
-    kawasu.microtable.setElementVis(tableControl, false);
+    kawasu.microtable.elementVis(tableControl, false);
 
-    // Show the data rowTables
     for (var i = 1; i < nodeListLength; ++i) {
         var table = rawTables.children[i];
-        kawasu.microtable.setElementVis(table, true); // Show table
-        kawasu.microtable.setElementVis(table.rows[0], true); // Show native header
+        if (bExpandable) {
+            kawasu.microtable.tableExpansionState(table, (i == indexCurrentRow)); // Show rows only for current rowTable
+        }
+        else {
+            kawasu.microtable.tableExpansionState(table, true);
+        }
+        kawasu.microtable.elementVis(table, true); // Show table
     }
+
 
     console.log(prefix + "Exiting");
 }
@@ -550,8 +564,8 @@ kawasu.microtable.textboxRowNavigate_onChange = function (event) {
     console.log(prefix + "INFO: id >" + tableId + "<");
 
     var arraySplit = tableId.split("_");
-    var sTableID = arraySplit[0];
-    console.log(prefix + "INFO: Table >" + sTableID + "<");
+    var sTableId = arraySplit[0];
+    console.log(prefix + "INFO: Table >" + sTableId + "<");
 
     // Get the value from the textbox
     var textbox = document.getElementById(textboxId);
@@ -568,7 +582,7 @@ kawasu.microtable.textboxRowNavigate_onChange = function (event) {
     console.log(prefix + "INFO: Value >" + nValue + "<");
 
     // Get refs
-    var tableControlId = kawasu.microtable.getTableId(sTableID, 0);
+    var tableControlId = kawasu.microtable.getTableId(sTableId, 0);
     var tableControl = document.getElementById(tableControlId);
     var rawTables = tableControl.parentNode;
     var rawTablesLength = rawTables.children.length;
@@ -588,10 +602,10 @@ kawasu.microtable.textboxRowNavigate_onChange = function (event) {
 
     // If this clean value causes a change to the currently selected row, 
     // change the current row and re-display
-    var indexCurrentRow = kawasu.microtable[sTableID]["indexCurrentRow"];
+    var indexCurrentRow = kawasu.microtable[sTableId]["indexCurrentRow"];
     if (indexCurrentRow != nCleanValue) {
-        kawasu.microtable[sTableID]["indexCurrentRow"] = nCleanValue;
-        kawasu.microtable.setViewStateStack(sTableID, rawTables, kawasu.microtable[sTableID]["indexCurrentRow"]);
+        kawasu.microtable[sTableId]["indexCurrentRow"] = nCleanValue;
+        kawasu.microtable.setViewStateStack(sTableId, rawTables, kawasu.microtable[sTableId]["indexCurrentRow"]);
     }
 
     console.log(prefix + "Exiting");
@@ -609,50 +623,50 @@ kawasu.microtable.btnRowNavigate_onClick = function () {
     console.log(prefix + "INFO: tableId >" + tableId + "<");
 
     var arraySplit = buttonId.split("_");
-    var sTableID = arraySplit[0];
+    var sTableId = arraySplit[0];
     var sBtnName = arraySplit[1];
 
     // Get ref to the array of raw tables...
-    var tableControlId = kawasu.microtable.getTableId(sTableID, 0);
+    var tableControlId = kawasu.microtable.getTableId(sTableId, 0);
     var tableControl = document.getElementById(tableControlId);
     var rawTables = tableControl.parentNode;
     var rawTablesLength = rawTables.children.length;
 
-    var indexCurrentRow = kawasu.microtable[sTableID]["indexCurrentRow"];
+    var indexCurrentRow = kawasu.microtable[sTableId]["indexCurrentRow"];
 
     // Get a ref to the textbox
-    var textboxId = sTableID + "_" + "textboxRowNavigate";
+    var textboxId = sTableId + "_" + "textboxRowNavigate";
     var textbox = document.getElementById(textboxId);
 
     switch (sBtnName) {
         case "btnRowFirst":
             if (indexCurrentRow != 1) {
                 textbox.value = 1;
-                kawasu.microtable[sTableID]["indexCurrentRow"] = 1;
-                kawasu.microtable.setViewStateStack(sTableID, rawTables, kawasu.microtable[sTableID]["indexCurrentRow"]);
+                kawasu.microtable[sTableId]["indexCurrentRow"] = 1;
+                kawasu.microtable.setViewStateStack(sTableId, rawTables, kawasu.microtable[sTableId]["indexCurrentRow"]);
             }
             break;
         case "btnRowLast":
             if (indexCurrentRow != (rawTablesLength - 1)) {
                 textbox.value = (rawTablesLength - 1);
-                kawasu.microtable[sTableID]["indexCurrentRow"] = (rawTablesLength - 1);
-                kawasu.microtable.setViewStateStack(sTableID, rawTables, kawasu.microtable[sTableID]["indexCurrentRow"]);
+                kawasu.microtable[sTableId]["indexCurrentRow"] = (rawTablesLength - 1);
+                kawasu.microtable.setViewStateStack(sTableId, rawTables, kawasu.microtable[sTableId]["indexCurrentRow"]);
             }
             break;
         case "btnRowPrev":
             if (indexCurrentRow > 1) {
                 var nextValue = indexCurrentRow - 1;
                 textbox.value = nextValue;
-                kawasu.microtable[sTableID]["indexCurrentRow"] = nextValue;
-                kawasu.microtable.setViewStateStack(sTableID, rawTables, kawasu.microtable[sTableID]["indexCurrentRow"]);
+                kawasu.microtable[sTableId]["indexCurrentRow"] = nextValue;
+                kawasu.microtable.setViewStateStack(sTableId, rawTables, kawasu.microtable[sTableId]["indexCurrentRow"]);
             }
             break;
         case "btnRowNext":
             if (indexCurrentRow < (rawTablesLength - 1)) {
                 var nextValue = indexCurrentRow + 1;
                 textbox.value = nextValue;
-                kawasu.microtable[sTableID]["indexCurrentRow"] = nextValue;
-                kawasu.microtable.setViewStateStack(sTableID, rawTables, kawasu.microtable[sTableID]["indexCurrentRow"]);
+                kawasu.microtable[sTableId]["indexCurrentRow"] = nextValue;
+                kawasu.microtable.setViewStateStack(sTableId, rawTables, kawasu.microtable[sTableId]["indexCurrentRow"]);
             }
             break;
         default:
@@ -661,7 +675,7 @@ kawasu.microtable.btnRowNavigate_onClick = function () {
     }
 
     // Regardless, populate the textbox in case it was blank before
-    textbox.value = kawasu.microtable[sTableID]["indexCurrentRow"];
+    textbox.value = kawasu.microtable[sTableId]["indexCurrentRow"];
 
     console.log(prefix + "Exiting");
 }
@@ -672,7 +686,8 @@ kawasu.microtable.checkboxSelect_onClick = function (event) {
 
     // User has clicked on a checkbox for either the Control table or a Row table
 
-    var checkboxId = event.target.id;
+    var checkbox = event.target;
+    var checkboxId = checkbox.id;
     var tableId = kawasu.microtable.getTableIdFromControlId(checkboxId);
     console.log(prefix + "INFO: checkboxId >" + checkboxId + "<");
     console.log(prefix + "INFO: tableId >" + tableId + "<");
@@ -681,16 +696,16 @@ kawasu.microtable.checkboxSelect_onClick = function (event) {
     var nSelectedTableIndex = parseInt(tableArraySplit[1], 10);
 
     var arraySplit = checkboxId.split("_");
-    var sTableID = arraySplit[0];
-    var bMultiSelect = kawasu.microtable[sTableID]["bMultiSelect"];
-    console.log(prefix + "INFO: Table >" + sTableID + "<");
+    var sTableId = arraySplit[0];
+    var bMultiSelect = kawasu.microtable[sTableId]["bMultiSelect"];
+    console.log(prefix + "INFO: Table >" + sTableId + "<");
 
     // Control Checkbox Name:                   
-    //      sTableID + "_" + "checkboxSelect"
+    //      sTableId + "_" + "checkboxSelect"
     // eg   "MyMicroTable_checkboxSelect"
     //
     // RowTable NativeHeader Checkbox Name:     
-    //      sTableID + "_" + fc.utils.prePad(nIndex.toString(), "0", kawasu.microtable.config.nZeroPadding); + "_" + "checkboxSelect"
+    //      sTableId + "_" + fc.utils.prePad(nIndex.toString(), "0", kawasu.microtable.config.nZeroPadding); + "_" + "checkboxSelect"
     // eg   "MyMicroTable_000001_checkboxSelect"
     // Note: getTableId() provides the first two parts of the name
 
@@ -701,18 +716,18 @@ kawasu.microtable.checkboxSelect_onClick = function (event) {
     if (arraySplit.length == 2) {
 
         // Get the Control Checkbox; Control Checkbox name only has two parts
-        var controlCheckboxId = sTableID + "_" + "checkboxSelect";
+        var controlCheckboxId = sTableId + "_" + "checkboxSelect";
         var controlCheckbox = document.getElementById(controlCheckboxId);
 
         // This row is being either selected or deselected...
-        var indexCurrentRow = kawasu.microtable[sTableID]["indexCurrentRow"];
+        var indexCurrentRow = kawasu.microtable[sTableId]["indexCurrentRow"];
 
         // Push the state of the checkbox to the rowTable checkbox
-        kawasu.microtable.pushSelectStateControlToRow(sTableID, indexCurrentRow, controlCheckbox.checked);
+        kawasu.microtable.pushSelectStateControlToRow(sTableId, indexCurrentRow, controlCheckbox.checked);
 
         // Enforce Single Select if applicable
         if (!bMultiSelect) {
-            kawasu.microtable.setSingleSelect(sTableID, indexCurrentRow);
+            kawasu.microtable.setSingleSelect(sTableId, indexCurrentRow);
         }
 
     }
@@ -722,8 +737,56 @@ kawasu.microtable.checkboxSelect_onClick = function (event) {
         // If we are in single select mode, turn off any other selections
 
         if (!bMultiSelect) {
-            // Single Select Case            
-            kawasu.microtable.setSingleSelect(sTableID, nSelectedTableIndex);
+            // Single Select Case 
+            // If the checkbox is being turned off, do nothing, but if it's being 
+            // turned on, you need to turn off the currently selected checkbox.           
+            if (checkbox.checked) {
+                kawasu.microtable.setSingleSelect(sTableId, nSelectedTableIndex);
+            }
+        }
+    }
+
+    console.log(prefix + "Exiting");
+}
+
+kawasu.microtable.thNativeHeader_onClick = function (event) {
+    var prefix = "kawasu.microtable.thNativeHeader_onClick() - ";
+    console.log(prefix + "Entering");
+
+    // User has clicked on a native header to compress or expand a row
+    var th = event.target;
+    var tableTarget = kawasu.microtable.getTableFromHeaderCell(th);
+    var tableTargetId = tableTarget.id;
+    var arraySplit = tableTargetId.split("_");
+    var sTableId = arraySplit[0];
+    kawasu.microtable[sTableId]["indexCurrentRow"] = parseInt(arraySplit[1],10);
+
+    var bExpandable = kawasu.microtable[sTableId]["bExpandable"];
+    var bMultiExpand = kawasu.microtable[sTableId]["bMultiExpand"];
+
+
+    if (!bExpandable) {
+        console.log(prefix + "WARNING: Table is not in EXPANDABLE mode, no action taken.");
+        console.log(prefix + "Exiting");
+        return;
+    }
+    // implicit else: table is expandable
+
+    if (bMultiExpand) {
+        // Table allows rows to be expanded/compressed independently.  
+        // Toggle the expansion state of this table.
+        kawasu.microtable.tableExpansionState(tableTarget) ?
+            kawasu.microtable.tableExpansionState(tableTarget, false) :
+            kawasu.microtable.tableExpansionState(tableTarget, true);
+    }
+    else {
+        // Table only allows one expanded row.
+        // Expand this row, compress all others.
+        var rawTables = tableTarget.parentNode;
+        var nodeListLength = rawTables.children.length;
+        for (var i = 0; i < nodeListLength; ++i) {
+            var table = rawTables.children[i];            
+            kawasu.microtable.tableExpansionState(table, (table.id == tableTarget.id));
         }
     }
 
@@ -736,25 +799,31 @@ kawasu.microtable.checkboxSelect_onClick = function (event) {
 
 
 
+
+
+
+
+
+
 ///////////////////////////////////////////////////////////////////////////////
 // ACTIONS
 //
 
-kawasu.microtable.deleteSelected = function (sTableID, bDeleteSourceData) {
+kawasu.microtable.deleteSelected = function (sTableId, bDeleteSourceData) {
     var prefix = "kawasu.microtable.deleteSelected() - ";
     console.log(prefix + "Entering");
 
     // Iterate the tables and build an array of selected items, and send this to delete routine
-    var array = kawasu.microtable.getSelectedIndices(sTableID);
+    var array = kawasu.microtable.getSelectedIndices(sTableId);
 
-    kawasu.microtable.itemsDelete(sTableID, array, bDeleteSourceData);
+    kawasu.microtable.itemsDelete(sTableId, array, bDeleteSourceData);
 
-    kawasu.microtable.applyViewState(sTableID);
+    kawasu.microtable.applyViewState(sTableId);
 
     console.log(prefix + "Exiting");
 }
 
-kawasu.microtable.itemsDelete = function (sTableID, arrRowsToDelete, bDeleteSourceData) {
+kawasu.microtable.itemsDelete = function (sTableId, arrRowsToDelete, bDeleteSourceData) {
     var prefix = "kawasu.microtable.itemsDelete() - ";
     console.log(prefix + "Entering");
 
@@ -766,10 +835,10 @@ kawasu.microtable.itemsDelete = function (sTableID, arrRowsToDelete, bDeleteSour
     // Default syntax - defaults to false, do not delete source data.
     bDeleteSourceData = typeof bDeleteSourceData !== 'undefined' ? bDeleteSourceData : false;
 
-    var rawTables = kawasu.microtable.getRawTables(sTableID);
+    var rawTables = kawasu.microtable.getRawTables(sTableId);
     var nodeListLength = rawTables.children.length;
-    var indexCurrentRow = kawasu.microtable[sTableID]["indexCurrentRow"];
-    var arrData = kawasu.microtable[sTableID]["arrData"];
+    var indexCurrentRow = kawasu.microtable[sTableId]["indexCurrentRow"];
+    var arrData = kawasu.microtable[sTableId]["arrData"];
 
     // Work out how many rows will be deleted before the current row.
     var nRowsBeforeCurrentToDelete = 0;
@@ -787,12 +856,12 @@ kawasu.microtable.itemsDelete = function (sTableID, arrRowsToDelete, bDeleteSour
     var nDataRowsRemaining = (nodeListLength - 1) - arrRowsToDelete.length;
     if (indexCurrentRow > nDataRowsRemaining) indexCurrentRow = nDataRowsRemaining;
 
-    kawasu.microtable[sTableID]["indexCurrentRow"] = indexCurrentRow;
+    kawasu.microtable[sTableId]["indexCurrentRow"] = indexCurrentRow;
 
     // Do the delete, backwards, so that indices in the data array are always valid
     for (var i = arrRowsToDelete.length; i > 0; --i) {
         var index = i - 1;
-        var tableToDeleteId = kawasu.microtable.getTableId(sTableID, arrRowsToDelete[index]);
+        var tableToDeleteId = kawasu.microtable.getTableId(sTableId, arrRowsToDelete[index]);
         var tableToDelete = document.getElementById(tableToDeleteId);
         rawTables.removeChild(tableToDelete);
         if (bDeleteSourceData) {
@@ -804,23 +873,23 @@ kawasu.microtable.itemsDelete = function (sTableID, arrRowsToDelete, bDeleteSour
     nodeListLength = rawTables.children.length;
     for (var i = 1; i < nodeListLength; ++i) {
         var table = rawTables.children[i];
-        table.id = kawasu.microtable.getTableId(sTableID, i);
+        table.id = kawasu.microtable.getTableId(sTableId, i);
         var th1 = table.rows[0].cells[0];
-        var sItemName = kawasu.microtable[sTableID]["sItemName"];
+        var sItemName = kawasu.microtable[sTableId]["sItemName"];
         fc.utils.textContent(th1, kawasu.microtable.getItemText(sItemName, i));
     }
 
     // Update the tooltip
-    kawasu.microtable.setLabelTooltipRowCount(sTableID);
+    kawasu.microtable.setLabelTooltipRowCount(sTableId);
 
     console.log(prefix + "Exiting");
 }
 
-kawasu.microtable.setSelectAll = function (sTableID, bSelect) {
+kawasu.microtable.setSelectAll = function (sTableId, bSelect) {
     var prefix = "kawasu.microtable.setSelectAll() - ";
     console.log(prefix + "Entering");
 
-    var bMultiSelect = kawasu.microtable[sTableID]["bMultiSelect"];
+    var bMultiSelect = kawasu.microtable[sTableId]["bMultiSelect"];
     if (bMultiSelect == false) {
         console.log(prefix + "WARNING: Cannot select all in Single Select Mode, no action will be taken.");
         console.log(prefix + "Exiting");
@@ -830,7 +899,7 @@ kawasu.microtable.setSelectAll = function (sTableID, bSelect) {
     // Default syntax - defaults to true, select all.
     bSelect = (typeof bSelect !== 'undefined') ? bSelect : true;
 
-    var rawTables = kawasu.microtable.getRawTables(sTableID);
+    var rawTables = kawasu.microtable.getRawTables(sTableId);
     var nodeListLength = rawTables.children.length;
 
     // Iterate tables, set select state.  
@@ -845,8 +914,32 @@ kawasu.microtable.setSelectAll = function (sTableID, bSelect) {
     console.log(prefix + "Exiting");
 }
 
+kawasu.microtable.refreshView = function (sTableId) {
+    var prefix = "kawasu.microtable.refreshView() - ";
+    console.log(prefix + "Entering");
+
+    // This fn is intended for use in testing: When a state variable is 
+    // changed, the system does not necessarily refresh the view.  This
+    // function gives an outside harness the ability to enforce a view update.
+
+    kawasu.microtable.applyViewState(sTableId);
+
+    console.log(prefix + "Exiting");
+}
 //
 ///////////////////////////////////////////////////////////////////////////////
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -854,7 +947,107 @@ kawasu.microtable.setSelectAll = function (sTableID, bSelect) {
 // PRIVATE HELPERS
 //
 
-kawasu.microtable.multiSelect = function (sTableID, bMultiSelect) {
+kawasu.microtable.isControlTable = function (table) {
+    var arraySplit = (table.id).split("_");
+    return (parseInt(arraySplit[1], 10) == 0);
+}
+
+
+kawasu.microtable.elementVis = function (element, bShow) {
+    if (typeof bShow === 'undefined') {
+        // Get: If element is not display:none, it is visible
+        return (element.style.display != "none");
+    }
+    else {
+        // Set
+        element.style.display = (bShow) ? "" : "none";
+        return bShow;
+    }
+}
+
+kawasu.microtable.tableExpansionState = function (table, bExpansionState) {
+    var prefix = "kawasu.microtable.tableExpansionState() - ";
+    console.log(prefix + "Entering");
+
+    // Get/Set for expansion state - true means expand this table, false means compress, no arg means return state
+
+    if (typeof bExpansionState !== 'undefined') {
+        // Set
+        console.log(prefix + "INFO: Setting expansion state to " + (bExpansionState ? "true" : "false") + " for table " + table.id);
+
+        // Iterate the rows of the table.
+        // If the row contains td elements, set the row to the given show state
+        var bIsControlTable = kawasu.microtable.isControlTable(table);
+        var nodeListLength = table.children.length;
+        for (var i = 0; i < nodeListLength; ++i) {
+            var row = table.children[i];
+            var cell = row.cells[0];
+            if (cell.nodeName == 'TD') {
+                // Data rows
+                kawasu.microtable.elementVis(row, bExpansionState);
+            }
+            else {
+                // Header rows
+                kawasu.microtable.elementVis(row, !(bIsControlTable && i == 0)); // Don't show the control table's zero row, show it's row[1] though
+                /*
+                if (bIsControlTable && i == 0) {
+                kawasu.microtable.elementVis(row, false);
+                }
+                else {
+
+                kawasu.microtable.elementVis(row, true);
+                }
+                */
+            }
+        }
+
+        console.log(prefix + "Exiting");
+        return bExpansionState;
+    }
+    else {
+        // Get
+
+        // If the last row is hidden, the whole table will be hidden
+        var lastRow = table.lastChild;
+        console.log(prefix + "Exiting");
+        return kawasu.microtable.elementVis(lastRow);
+    }
+}
+
+
+kawasu.microtable.expandable = function (sTableId, bExpandable) {
+    var prefix = "kawasu.microtable.expandable() - ";
+    console.log(prefix + "Entering");
+
+    // Get/Set for expandable state - true means yes, this table allows row compression/expansion
+
+    if (typeof bExpandable !== 'undefined') {
+        // Set
+        console.log(prefix + "INFO: Setting bExpandable to " + (bExpandable ? "true" : "false"));
+        kawasu.microtable[sTableId]["bExpandable"] = bExpandable;
+    }
+
+    console.log(prefix + "Exiting");
+    return kawasu.microtable[sTableId]["bExpandable"];
+}
+
+kawasu.microtable.multiExpand = function (sTableId, bMultiExpand) {
+    var prefix = "kawasu.microtable.multiExpand() - ";
+    console.log(prefix + "Entering");
+
+    // Get/Set for multiexpand state - true means yes, this table allows multiple rows expanded at the same time
+
+    if (typeof bMultiExpand !== 'undefined') {
+        // Set
+        console.log(prefix + "INFO: Setting bMultiExpand to " + (bMultiExpand ? "true" : "false"));
+        kawasu.microtable[sTableId]["bMultiExpand"] = bMultiExpand;
+    }
+
+    console.log(prefix + "Exiting");
+    return kawasu.microtable[sTableId]["bMultiExpand"];
+}
+
+kawasu.microtable.multiSelect = function (sTableId, bMultiSelect) {
     var prefix = "kawasu.microtable.multiSelect() - ";
     console.log(prefix + "Entering");
 
@@ -863,15 +1056,15 @@ kawasu.microtable.multiSelect = function (sTableID, bMultiSelect) {
     if (typeof bMultiSelect !== 'undefined') {
         // Set
         console.log(prefix + "INFO: Setting bMultiSelect to " + (bMultiSelect ? "true" : "false"));
-        kawasu.microtable[sTableID]["bMultiSelect"] = bMultiSelect;
+        kawasu.microtable[sTableId]["bMultiSelect"] = bMultiSelect;
     }
 
     console.log(prefix + "Exiting");
-    return kawasu.microtable[sTableID]["bMultiSelect"];
+    return kawasu.microtable[sTableId]["bMultiSelect"];
 }
 
-kawasu.microtable.getTableId = function (sTableID, nIndex) {
-    return sTableID + "_" + fc.utils.prePad(nIndex.toString(), "0", kawasu.microtable.config.nZeroPadding);
+kawasu.microtable.getTableId = function (sTableId, nIndex) {
+    return sTableId + "_" + fc.utils.prePad(nIndex.toString(), "0", kawasu.microtable.config.nZeroPadding);
 }
 
 kawasu.microtable.getItemText = function (sItemName, nIndex) {
@@ -888,24 +1081,24 @@ kawasu.microtable.countHeaders = function (header) {
     return countHeaders;
 }
 
-kawasu.microtable.getRawTables = function (sTableID) {
+kawasu.microtable.getRawTables = function (sTableId) {
     // Once the raw tables have been created, they get attached to the main doc,
     // and we lose track of them.  To find the owner, get the control and get
     // it's parent.  Always use 'children' not 'childnodes' to access siblings.
-    var controlTableId = kawasu.microtable.getTableId(sTableID, 0);
+    var controlTableId = kawasu.microtable.getTableId(sTableId, 0);
     var controlTable = document.getElementById(controlTableId);
     return controlTable.parentNode;
 }
 
-kawasu.microtable.setLabelTooltipRowCount = function (sTableID) {
+kawasu.microtable.setLabelTooltipRowCount = function (sTableId) {
     // Work out how many data rows there are, and set the tooltip accordingly
-    var rawTables = kawasu.microtable.getRawTables(sTableID);
+    var rawTables = kawasu.microtable.getRawTables(sTableId);
     var tableControl = rawTables.children[0];
     var tr = tableControl.rows[0];
     var th1 = tr.cells[0];
     var label = th1.children[0];
 
-    var sItemName = kawasu.microtable[sTableID]["sItemName"];
+    var sItemName = kawasu.microtable[sTableId]["sItemName"];
     var nDataRows = rawTables.children.length - 1;
 
     label.title = kawasu.microtable.getLabelTooltip(sItemName, nDataRows);
@@ -922,6 +1115,17 @@ kawasu.microtable.getTableIdFromControlId = function (controlId) {
     var tr = cell.parentNode;
     var table = tr.parentNode;
     return table.id;
+
+    console.log(prefix + "Exiting");
+}
+
+kawasu.microtable.getTableFromHeaderCell = function (th) {
+    var prefix = "kawasu.microtable.getTableFromHeaderCell() - ";
+    console.log(prefix + "Entering");
+
+    var tr = th.parentNode;
+    var table = tr.parentNode;
+    return table;
 
     console.log(prefix + "Exiting");
 }
@@ -944,7 +1148,7 @@ kawasu.microtable.getCheckboxFromTable = function (table) {
 
     var tableId = table.id;
     var arraySplit = tableId.split("_");
-    var sTableID = arraySplit[0];
+    var sTableId = arraySplit[0];
     var zeroIndex = parseInt(arraySplit[1]);
     var checkboxId = "";
 
@@ -960,11 +1164,11 @@ kawasu.microtable.getCheckboxFromTable = function (table) {
     }
 }
 
-kawasu.microtable.pushSelectStateControlToRow = function (sTableID, nSelectedIndex, bState) {
+kawasu.microtable.pushSelectStateControlToRow = function (sTableId, nSelectedIndex, bState) {
     var prefix = "kawasu.microtable.pushSelectStateControlToRow() - ";
     console.log(prefix + "Entering");
 
-    var rawTables = kawasu.microtable.getRawTables(sTableID);
+    var rawTables = kawasu.microtable.getRawTables(sTableId);
     var table = rawTables.children[nSelectedIndex];
     var checkbox = kawasu.microtable.getCheckboxFromTable(table);
     checkbox.checked = bState;
@@ -972,14 +1176,14 @@ kawasu.microtable.pushSelectStateControlToRow = function (sTableID, nSelectedInd
     console.log(prefix + "Exiting");
 }
 
-kawasu.microtable.setSingleSelect = function (sTableID, nSelectedIndex) {
+kawasu.microtable.setSingleSelect = function (sTableId, nSelectedIndex) {
     var prefix = "kawasu.microtable.setSingleSelect() - ";
     console.log(prefix + "Entering");
 
     // RowTable 'nSelectedIndex' has been selected, and we are in Single Select
     // mode, so set the other rowTables to not selected.
 
-    var rawTables = kawasu.microtable.getRawTables(sTableID);
+    var rawTables = kawasu.microtable.getRawTables(sTableId);
     var nodeListLength = rawTables.children.length;
 
     // Single Select
@@ -997,12 +1201,12 @@ kawasu.microtable.setSingleSelect = function (sTableID, nSelectedIndex) {
     console.log(prefix + "Exiting");
 }
 
-kawasu.microtable.getSelectedIndices = function (sTableID) {
+kawasu.microtable.getSelectedIndices = function (sTableId) {
     var prefix = "kawasu.microtable.getSelectedIndices() - ";
     console.log(prefix + "Entering");
 
     var arraySelected = [];
-    var rawTables = kawasu.microtable.getRawTables(sTableID);
+    var rawTables = kawasu.microtable.getRawTables(sTableId);
     var nodeListLength = rawTables.children.length;
 
     for (var i = 1; i < nodeListLength; ++i) {
@@ -1019,13 +1223,13 @@ kawasu.microtable.getSelectedIndices = function (sTableID) {
     return arraySelected;
 }
 
-kawasu.microtable.addRow = function (sTableID, table, bHeader, sCell1Text, sCell2Text) {
-    var prefix = "kawasu.microtable.addRow() - ";
-    console.log(prefix + "Entering");
+kawasu.microtable.addRow = function (sTableId, table, bHeader, sCell1Text, sCell2Text) {
+    //var prefix = "kawasu.microtable.addRow() - ";
+    //console.log(prefix + "Entering");
 
     // Creates a row and adds it to a table, and returns a ref to the row
 
-    var styleDefn = kawasu.microtable[sTableID]["styleDefn"];
+    var styleDefn = kawasu.microtable[sTableId]["styleDefn"];
 
     var classRowHeader = styleDefn["trClassHeader"] || "";
     var classHeaderCell = styleDefn["thClass"] || "";
@@ -1036,13 +1240,26 @@ kawasu.microtable.addRow = function (sTableID, table, bHeader, sCell1Text, sCell
 
     var cellType = (bHeader ? "th" : "td");
 
+    // Build some id's
+    var tableId = table.id;
+    var arraySplit = tableId.split("_");
+    var sTableIndex = arraySplit[1]; // [0]=sTableId,[1]="000000" etc
+    var nCurrentRowCount = table.children.length; // Next index is this value
+    var sCurrentRowCount = fc.utils.prePad(nCurrentRowCount.toString(),"0",4);
+
+    var sRowId = sTableId + "_" + sTableIndex + "_" + "tr" + "_" + sCurrentRowCount;
+    var sCell1Id = sRowId + "_" + cellType + "1";
+    var sCell2Id = sRowId + "_" + cellType + "2";
+
     var tr = document.createElement("tr");
     tr.className = bHeader ? classRowHeader : classRowData;
+    tr.id = sRowId;
 
     // First column cell
     var cellCol1 = document.createElement(cellType);
     var cellCol1Class = (bHeader ? classHeaderCell : classCellKey) + " " + classCol1;
     cellCol1.className = cellCol1Class;
+    cellCol1.id = sCell1Id;
     if (typeof sCell1Text === 'undefined' || fc.utils.isEmptyStringOrWhiteSpace(sCell1Text)) {
         cellCol1.innerHTML = kawasu.microtable.config.sEmptyStringHtml;
     }
@@ -1054,6 +1271,7 @@ kawasu.microtable.addRow = function (sTableID, table, bHeader, sCell1Text, sCell
     var cellCol2 = document.createElement(cellType);
     var cellCol2Class = (bHeader ? classHeaderCell : classCellValue)
     cellCol2.className = cellCol2Class;
+    cellCol2.id = sCell2Id;
     if (typeof sCell2Text === 'undefined' || fc.utils.isEmptyStringOrWhiteSpace(sCell2Text)) {
         cellCol2.innerHTML = kawasu.microtable.config.sEmptyStringHtml;
     }
@@ -1068,7 +1286,7 @@ kawasu.microtable.addRow = function (sTableID, table, bHeader, sCell1Text, sCell
     tr.appendChild(cellCol2);
     table.appendChild(tr);
 
-    console.log(prefix + "Exiting");
+    //console.log(prefix + "Exiting");
 
     return tr;
 }


### PR DESCRIPTION
ADDED: Click routine for vertical table native header cells
ADDED: Helper fn to get/set expansion state of tables
ADDED: Naming for rows, possibly not required
FIXED: In single select mode, could not turn off a click, now you can
ADDED: Harness routines to test modes
CHANGED: sTableID to sTableId to normalise across the codebase
CHANGED: setElementVis() to elementVis() so that it is both getter'n'setter
